### PR TITLE
Allow returning full subagent state + messages in supervisor.

### DIFF
--- a/langgraph_supervisor/supervisor.py
+++ b/langgraph_supervisor/supervisor.py
@@ -54,7 +54,10 @@ def _make_call_agent(
         if add_handoff_back_messages:
             messages.extend(create_handoff_back_messages(agent.name, supervisor_name))
 
-        return output
+        return {
+            **output,
+            "messages": messages,
+        }
 
     def call_agent(state: dict) -> dict:
         output = agent.invoke(state)

--- a/langgraph_supervisor/supervisor.py
+++ b/langgraph_supervisor/supervisor.py
@@ -54,7 +54,7 @@ def _make_call_agent(
         if add_handoff_back_messages:
             messages.extend(create_handoff_back_messages(agent.name, supervisor_name))
 
-        return {"messages": messages}
+        return output
 
     return call_agent
 


### PR DESCRIPTION
### **Description**
This PR modifies the **LangGraph Supervisor** to return the **full subagent state** instead of just `messages`.  
Previously, `_make_call_agent` only returned `{"messages": messages}`, which **prevented the supervisor from accessing additional state information** from subagents.

Now, `_make_call_agent` **returns the full `output`**, ensuring that:
- ✅ **All state values** (e.g., `config` etc.) are preserved.
- ✅ **Messages remain intact** while allowing additional context to flow between agents.
- ✅ **No breaking changes**, just an improvement to data availability.

### **Changes**
- Updated `_make_call_agent` to return `output` instead of only `messages`.

### **Impact**
- **Allows better state tracking** within the supervisor.
- **Supports more complex multi-agent workflows**.
- **No changes required** for existing users; it just **enhances state accessibility**.
